### PR TITLE
Added a crash logger/reporter for Bully when crashed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,9 @@ App_Data/*.ldf
 *.bim.layout
 *.bim_*.settings
 
+# Local convenience build script (not part of upstream)
+build.bat
+
 # Microsoft Fakes
 FakesAssemblies/
 

--- a/SilentPatchBully/CrashReporter/CrashReporter.cpp
+++ b/SilentPatchBully/CrashReporter/CrashReporter.cpp
@@ -271,6 +271,49 @@ namespace CrashReporter
 	}
 
 	// ------------------------------------------------------------------
+	// Enumerate loaded modules
+	// ------------------------------------------------------------------
+	struct ModuleEntry
+	{
+		char name[MAX_PATH];
+		char path[MAX_PATH];
+		uint32_t base;
+		uint32_t size;
+	};
+
+	static int EnumerateModules( ModuleEntry* entries, int maxEntries )
+	{
+		HMODULE hMods[256];
+		DWORD cbNeeded;
+		HANDLE hProcess = GetCurrentProcess();
+		int count = 0;
+
+		if ( EnumProcessModules( hProcess, hMods, sizeof(hMods), &cbNeeded ) )
+		{
+			int numMods = cbNeeded / sizeof(HMODULE);
+			if ( numMods > maxEntries ) numMods = maxEntries;
+			for ( int i = 0; i < numMods; i++ )
+			{
+				MODULEINFO modInfo = {};
+				if ( GetModuleInformation( hProcess, hMods[i], &modInfo, sizeof(modInfo) ) )
+				{
+					entries[count].base = (uint32_t)(uintptr_t)modInfo.lpBaseOfDll;
+					entries[count].size = (uint32_t)modInfo.SizeOfImage;
+
+					char fullPath[MAX_PATH] = {};
+					GetModuleFileNameExA( hProcess, hMods[i], fullPath, MAX_PATH );
+					strncpy_s( entries[count].path, fullPath, _TRUNCATE );
+
+					char* bn = strrchr( fullPath, '\\' );
+					strncpy_s( entries[count].name, bn != nullptr ? bn + 1 : fullPath, _TRUNCATE );
+					count++;
+				}
+			}
+		}
+		return count;
+	}
+
+	// ------------------------------------------------------------------
 	// Write JSON crash report
 	// ------------------------------------------------------------------
 	static void WriteCrashJson( const wchar_t* path, DWORD exceptionCode, PVOID faultAddr,
@@ -278,7 +321,7 @@ namespace CrashReporter
 		const OSInfo& os, const MemoryInfo& mem, const GPUInfo& gpu, const ProcessInfo& proc )
 	{
 		FILE* f = nullptr;
-		if ( _wfopen_s( &f, path, L"w, ccs=UTF-8" ) != 0 || f == nullptr )
+		if ( _wfopen_s( &f, path, L"w" ) != 0 || f == nullptr )
 			return;
 
 		// SilentPatch version
@@ -394,15 +437,45 @@ namespace CrashReporter
 		fprintf( f, "    \"large_address_aware\": %s\n", mem.largeAddressAware ? "true" : "false" );
 		fprintf( f, "  },\n" );
 
+		// modules block
+		ModuleEntry modules[256];
+		int moduleCount = EnumerateModules( modules, 256 );
+		fprintf( f, "  \"modules\": [\n" );
+		for ( int i = 0; i < moduleCount; i++ )
+		{
+			fprintf( f, "    {\n" );
+			fprintf( f, "      \"name\": " );
+			WriteJsonString( f, modules[i].name );
+			fprintf( f, ",\n" );
+			fprintf( f, "      \"base\": \"0x%08X\",\n", modules[i].base );
+			fprintf( f, "      \"size\": %lu\n", modules[i].size );
+			fprintf( f, "    }" );
+			if ( i + 1 < moduleCount ) fprintf( f, "," );
+			fprintf( f, "\n" );
+		}
+		fprintf( f, "  ],\n" );
+
 		// gpu block
 		fprintf( f, "  \"gpu\": {\n" );
-		fprintf( f, "    \"adapter\": " );
-		WriteJsonWString( f, gpu.adapterName );
-		fprintf( f, ",\n" );
-		fprintf( f, "    \"vram_mb\": %llu,\n", gpu.vramMB );
 		fprintf( f, "    \"driver_date\": " );
 		WriteJsonWString( f, gpu.driverDate );
-		fprintf( f, "\n  },\n" );
+		fprintf( f, ",\n" );
+		fprintf( f, "    \"adapters\": [\n" );
+		for ( uint32_t i = 0; i < gpu.adapterCount; i++ )
+		{
+			fprintf( f, "      {\n" );
+			fprintf( f, "        \"name\": " );
+			WriteJsonWString( f, gpu.adapters[i].name );
+			fprintf( f, ",\n" );
+			fprintf( f, "        \"vram_mb\": %llu,\n", gpu.adapters[i].vramMB );
+			fprintf( f, "        \"shared_mb\": %llu,\n", gpu.adapters[i].sharedMB );
+			fprintf( f, "        \"is_integrated\": %s\n", gpu.adapters[i].isIntegrated ? "true" : "false" );
+			fprintf( f, "      }" );
+			if ( i + 1 < gpu.adapterCount ) fprintf( f, "," );
+			fprintf( f, "\n" );
+		}
+		fprintf( f, "    ]\n" );
+		fprintf( f, "  },\n" );
 
 		// process block
 		fprintf( f, "  \"process\": {\n" );
@@ -548,21 +621,21 @@ namespace CrashReporter
 			return EXCEPTION_CONTINUE_SEARCH;
 		}
 
-		// Build base path next to the ASI file
-		wchar_t asiPath[MAX_PATH];
-		if ( GetModuleFileNameW( g_hModule, asiPath, MAX_PATH ) == 0 )
+		// Build base path in the game executable's directory
+		wchar_t gamePath[MAX_PATH];
+		if ( GetModuleFileNameW( GetModuleHandle(nullptr), gamePath, MAX_PATH ) == 0 )
 		{
 			return EXCEPTION_CONTINUE_SEARCH;
 		}
 
 		// Strip filename to get directory
-		wchar_t* lastSlash = wcsrchr( asiPath, L'\\' );
+		wchar_t* lastSlash = wcsrchr( gamePath, L'\\' );
 		if ( lastSlash != nullptr )
 			*(lastSlash + 1) = L'\0';
 
 		// Create crash_reports directory
 		wchar_t reportsDir[MAX_PATH];
-		swprintf_s( reportsDir, L"%scrash_reports\\", asiPath );
+		swprintf_s( reportsDir, L"%scrash_reports\\", gamePath );
 		EnsureDirectory( reportsDir );
 
 		// Create timestamped subdirectory

--- a/SilentPatchBully/CrashReporter/CrashReporter.cpp
+++ b/SilentPatchBully/CrashReporter/CrashReporter.cpp
@@ -1,0 +1,620 @@
+#include "CrashReporter.h"
+#include "SystemInfo.h"
+
+#include <windows.h>
+#include <intrin.h>
+#include <dbghelp.h>
+#include <psapi.h>
+#include <shlwapi.h>
+
+#pragma comment(lib, "dbghelp.lib")
+#pragma comment(lib, "psapi.lib")
+#pragma comment(lib, "shlwapi.lib")
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+
+namespace CrashReporter
+{
+	static HINSTANCE g_hModule = nullptr;
+	static bool g_enabled = true;
+	static volatile LONG g_installed = 0;
+	static DWORD g_startTick = 0;
+	static char g_gameState[256] = { 0 };
+
+	// Version info from build system
+	extern "C" uint32_t GetBuildNumber();
+
+	void SetEnabled( bool enable )
+	{
+		g_enabled = enable;
+	}
+
+	bool IsEnabled()
+	{
+		return g_enabled;
+	}
+
+	void SetGameState( const char* state )
+	{
+		if ( state == nullptr ) return;
+		size_t len = strlen( state );
+		if ( len >= sizeof(g_gameState) ) len = sizeof(g_gameState) - 1;
+		memcpy( (void*)g_gameState, state, len );
+		((char*)g_gameState)[len] = '\0';
+	}
+
+	// ------------------------------------------------------------------
+	// Helper: ensure directory exists
+	// ------------------------------------------------------------------
+	static bool EnsureDirectory( const wchar_t* path )
+	{
+		DWORD attribs = GetFileAttributesW( path );
+		if ( attribs != INVALID_FILE_ATTRIBUTES && (attribs & FILE_ATTRIBUTE_DIRECTORY) )
+			return true;
+		return CreateDirectoryW( path, nullptr ) != 0 || GetLastError() == ERROR_ALREADY_EXISTS;
+	}
+
+	// ------------------------------------------------------------------
+	// Helper: write JSON string escaping
+	// ------------------------------------------------------------------
+	static void WriteJsonString( FILE* f, const char* str )
+	{
+		fputc( '"', f );
+		if ( str != nullptr )
+		{
+			for ( const char* p = str; *p != '\0'; ++p )
+			{
+				switch ( *p )
+				{
+				case '"':  fputs( "\\\"", f ); break;
+				case '\\': fputs( "\\\\", f ); break;
+				case '\b': fputs( "\\b", f ); break;
+				case '\f': fputs( "\\f", f ); break;
+				case '\n': fputs( "\\n", f ); break;
+				case '\r': fputs( "\\r", f ); break;
+				case '\t': fputs( "\\t", f ); break;
+				default:
+					if ( (unsigned char)*p < 0x20 )
+						fprintf( f, "\\u%04x", (unsigned char)*p );
+					else
+						fputc( *p, f );
+					break;
+				}
+			}
+		}
+		fputc( '"', f );
+	}
+
+	static void WriteJsonWString( FILE* f, const wchar_t* wstr )
+	{
+		char utf8[512] = { 0 };
+		if ( wstr != nullptr )
+		{
+			WideCharToMultiByte( CP_UTF8, 0, wstr, -1, utf8, sizeof(utf8), nullptr, nullptr );
+		}
+		WriteJsonString( f, utf8 );
+	}
+
+	// ------------------------------------------------------------------
+	// Minidump callback: strip heap / private memory
+	// ------------------------------------------------------------------
+	static BOOL CALLBACK MiniDumpCallback( PVOID,
+		const PMINIDUMP_CALLBACK_INPUT CallbackInput,
+		PMINIDUMP_CALLBACK_OUTPUT CallbackOutput )
+	{
+		if ( CallbackInput == nullptr || CallbackOutput == nullptr )
+			return FALSE;
+
+		switch ( CallbackInput->CallbackType )
+		{
+			case IncludeModuleCallback:
+			case IncludeThreadCallback:
+			case ThreadCallback:
+			case ModuleCallback:
+				return TRUE;
+
+			case MemoryCallback:
+				// Don't include arbitrary memory regions
+				return FALSE;
+
+			case CancelCallback:
+				return FALSE;
+		}
+		return FALSE;
+	}
+
+	// ------------------------------------------------------------------
+	// Stack trace with StackWalk64 + symbol fallback
+	// ------------------------------------------------------------------
+	struct StackFrame
+	{
+		uint32_t addr;
+		char moduleName[64];
+		char symbolName[256];
+		uint32_t offset;
+	};
+
+	static int CaptureStackTrace( CONTEXT* ctx, StackFrame* frames, int maxFrames )
+	{
+		if ( maxFrames <= 0 ) return 0;
+
+		HMODULE hDbgHelp = LoadLibraryA( "dbghelp.dll" );
+		if ( hDbgHelp == nullptr )
+		{
+			// Fallback to EBP walk
+			int count = 0;
+			__try
+			{
+				uint32_t* frame = (uint32_t*)ctx->Ebp;
+				for ( int i = 0; i < maxFrames && frame != nullptr; i++ )
+				{
+					uint32_t retAddr = frame[1];
+					if ( retAddr == 0 || retAddr < 0x10000 ) break;
+
+					frames[count].addr = retAddr;
+					frames[count].moduleName[0] = '\0';
+					frames[count].symbolName[0] = '\0';
+					frames[count].offset = 0;
+
+					HMODULE hFrameMod = nullptr;
+					if ( GetModuleHandleExA( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)retAddr, &hFrameMod ) )
+					{
+						char modPath[MAX_PATH] = { 0 };
+						GetModuleFileNameA( hFrameMod, modPath, MAX_PATH );
+						char* bn = strrchr( modPath, '\\' );
+						strncpy_s( frames[count].moduleName, bn != nullptr ? bn + 1 : modPath, _TRUNCATE );
+						frames[count].offset = (uint32_t)(retAddr - (uintptr_t)hFrameMod);
+					}
+					count++;
+
+					uint32_t nextFrame = frame[0];
+					if ( nextFrame <= (uint32_t)frame || nextFrame > ctx->Esp + 0x100000 ) break;
+					frame = (uint32_t*)nextFrame;
+				}
+			}
+			__except ( EXCEPTION_EXECUTE_HANDLER ) {}
+			return count;
+		}
+
+		using SymInitialize_t = BOOL (WINAPI*)( HANDLE, PCSTR, BOOL );
+		using SymCleanup_t = BOOL (WINAPI*)( HANDLE );
+		using StackWalk64_t = BOOL (WINAPI*)( DWORD, HANDLE, HANDLE, LPSTACKFRAME64, PVOID, PREAD_PROCESS_MEMORY_ROUTINE64,
+			PFUNCTION_TABLE_ACCESS_ROUTINE64, PGET_MODULE_BASE_ROUTINE64, PTRANSLATE_ADDRESS_ROUTINE64 );
+		using SymFromAddr_t = BOOL (WINAPI*)( HANDLE, DWORD64, PDWORD64, PSYMBOL_INFO );
+		using SymGetModuleBase64_t = DWORD64 (WINAPI*)( HANDLE, DWORD64 );
+		using SymFunctionTableAccess64_t = PVOID (WINAPI*)( HANDLE, DWORD64 );
+		using SymSetOptions_t = DWORD (WINAPI*)( DWORD );
+
+		auto pSymInitialize = (SymInitialize_t)GetProcAddress( hDbgHelp, "SymInitialize" );
+		auto pSymCleanup = (SymCleanup_t)GetProcAddress( hDbgHelp, "SymCleanup" );
+		auto pStackWalk64 = (StackWalk64_t)GetProcAddress( hDbgHelp, "StackWalk64" );
+		auto pSymFromAddr = (SymFromAddr_t)GetProcAddress( hDbgHelp, "SymFromAddr" );
+		auto pSymGetModuleBase64 = (SymGetModuleBase64_t)GetProcAddress( hDbgHelp, "SymGetModuleBase64" );
+		auto pSymFunctionTableAccess64 = (SymFunctionTableAccess64_t)GetProcAddress( hDbgHelp, "SymFunctionTableAccess64" );
+		auto pSymSetOptions = (SymSetOptions_t)GetProcAddress( hDbgHelp, "SymSetOptions" );
+
+		if ( pSymInitialize == nullptr || pStackWalk64 == nullptr )
+		{
+			FreeLibrary( hDbgHelp );
+			return 0;
+		}
+
+		HANDLE hProcess = GetCurrentProcess();
+		if ( pSymSetOptions )
+			pSymSetOptions( SYMOPT_DEFERRED_LOADS | SYMOPT_UNDNAME | SYMOPT_LOAD_LINES );
+		pSymInitialize( hProcess, nullptr, TRUE );
+
+		STACKFRAME64 stackFrame = {};
+		DWORD machineType = IMAGE_FILE_MACHINE_I386;
+
+		stackFrame.AddrPC.Offset = ctx->Eip;
+		stackFrame.AddrPC.Mode = AddrModeFlat;
+		stackFrame.AddrFrame.Offset = ctx->Ebp;
+		stackFrame.AddrFrame.Mode = AddrModeFlat;
+		stackFrame.AddrStack.Offset = ctx->Esp;
+		stackFrame.AddrStack.Mode = AddrModeFlat;
+
+		int count = 0;
+		CONTEXT walkCtx = *ctx;
+		for ( int i = 0; i < maxFrames; i++ )
+		{
+			if ( !pStackWalk64( machineType, hProcess, GetCurrentThread(), &stackFrame, &walkCtx,
+				nullptr, pSymFunctionTableAccess64, pSymGetModuleBase64, nullptr ) )
+				break;
+
+			if ( stackFrame.AddrPC.Offset == 0 )
+				break;
+
+			frames[count].addr = (uint32_t)stackFrame.AddrPC.Offset;
+			frames[count].moduleName[0] = '\0';
+			frames[count].symbolName[0] = '\0';
+			frames[count].offset = 0;
+
+			// Module name
+			DWORD64 modBase = pSymGetModuleBase64 ? pSymGetModuleBase64( hProcess, stackFrame.AddrPC.Offset ) : 0;
+			if ( modBase != 0 )
+			{
+				frames[count].offset = (uint32_t)(stackFrame.AddrPC.Offset - modBase);
+				HMODULE hMod = nullptr;
+				if ( GetModuleHandleExA( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)(uintptr_t)stackFrame.AddrPC.Offset, &hMod ) )
+				{
+					char modPath[MAX_PATH] = { 0 };
+					GetModuleFileNameA( hMod, modPath, MAX_PATH );
+					char* bn = strrchr( modPath, '\\' );
+					strncpy_s( frames[count].moduleName, bn != nullptr ? bn + 1 : modPath, _TRUNCATE );
+				}
+			}
+
+			// Symbol name
+			if ( pSymFromAddr != nullptr )
+			{
+				alignas(16) char symBuffer[sizeof(SYMBOL_INFO) + 255] = {};
+				PSYMBOL_INFO pSym = (PSYMBOL_INFO)symBuffer;
+				pSym->SizeOfStruct = sizeof(SYMBOL_INFO);
+				pSym->MaxNameLen = 256;
+				DWORD64 disp = 0;
+				if ( pSymFromAddr( hProcess, stackFrame.AddrPC.Offset, &disp, pSym ) )
+				{
+					strncpy_s( frames[count].symbolName, pSym->Name, _TRUNCATE );
+				}
+			}
+
+			count++;
+		}
+
+		pSymCleanup( hProcess );
+		FreeLibrary( hDbgHelp );
+		return count;
+	}
+
+	// ------------------------------------------------------------------
+	// Write JSON crash report
+	// ------------------------------------------------------------------
+	static void WriteCrashJson( const wchar_t* path, DWORD exceptionCode, PVOID faultAddr,
+		CONTEXT* ctx, const StackFrame* frames, int frameCount,
+		const OSInfo& os, const MemoryInfo& mem, const GPUInfo& gpu, const ProcessInfo& proc )
+	{
+		FILE* f = nullptr;
+		if ( _wfopen_s( &f, path, L"w, ccs=UTF-8" ) != 0 || f == nullptr )
+			return;
+
+		// SilentPatch version
+		uint32_t build = GetBuildNumber();
+		uint32_t revision = (build >> 8) & 0xFF;
+		uint32_t buildId = build & 0xFF;
+
+		// Timestamp
+		SYSTEMTIME st;
+		GetLocalTime( &st );
+		char timestamp[64];
+		snprintf( timestamp, sizeof(timestamp), "%04d-%02d-%02d %02d:%02d:%02d",
+			st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond );
+
+		fprintf( f, "{\n" );
+
+		// silentpatch block
+		fprintf( f, "  \"silentpatch\": {\n" );
+		fprintf( f, "    \"version\": \"%u.%u.%u\",\n", revision, buildId, 0 );
+		fprintf( f, "    \"build\": %u,\n", buildId );
+		fprintf( f, "    \"revision\": %u,\n", revision );
+		fprintf( f, "    \"game\": " );
+		WriteJsonString( f, "Bully: Scholarship Edition" );
+		fprintf( f, "\n  },\n" );
+
+		// crash block
+		fprintf( f, "  \"crash\": {\n" );
+		fprintf( f, "    \"timestamp\": " );
+		WriteJsonString( f, timestamp );
+		fprintf( f, ",\n" );
+		fprintf( f, "    \"exception_code\": \"0x%08X\",\n", exceptionCode );
+		fprintf( f, "    \"fault_address\": \"0x%08X\"", (uint32_t)faultAddr );
+
+		HMODULE hFaultMod = nullptr;
+		if ( GetModuleHandleExA( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)faultAddr, &hFaultMod ) )
+		{
+			fprintf( f, ",\n    \"fault_module\": " );
+			char modPath[MAX_PATH] = { 0 };
+			GetModuleFileNameA( hFaultMod, modPath, MAX_PATH );
+			char* bn = strrchr( modPath, '\\' );
+			WriteJsonString( f, bn != nullptr ? bn + 1 : modPath );
+			fprintf( f, ",\n    \"fault_rva\": \"0x%08X\"", (uint32_t)((uintptr_t)faultAddr - (uintptr_t)hFaultMod) );
+		}
+
+		// AV details
+		if ( exceptionCode == EXCEPTION_ACCESS_VIOLATION )
+		{
+			// We don't have ExceptionInformation here, skip it in JSON to keep it simple
+			// The minidump and text log have the full details
+		}
+
+		fprintf( f, "\n  },\n" );
+
+		// registers block
+		fprintf( f, "  \"registers\": {\n" );
+		fprintf( f, "    \"eax\": \"0x%08X\",\n", ctx->Eax );
+		fprintf( f, "    \"ecx\": \"0x%08X\",\n", ctx->Ecx );
+		fprintf( f, "    \"edx\": \"0x%08X\",\n", ctx->Edx );
+		fprintf( f, "    \"ebx\": \"0x%08X\",\n", ctx->Ebx );
+		fprintf( f, "    \"esp\": \"0x%08X\",\n", ctx->Esp );
+		fprintf( f, "    \"ebp\": \"0x%08X\",\n", ctx->Ebp );
+		fprintf( f, "    \"esi\": \"0x%08X\",\n", ctx->Esi );
+		fprintf( f, "    \"edi\": \"0x%08X\",\n", ctx->Edi );
+		fprintf( f, "    \"eip\": \"0x%08X\",\n", ctx->Eip );
+		fprintf( f, "    \"eflags\": \"0x%08X\"\n", ctx->EFlags );
+		fprintf( f, "  },\n" );
+
+		// stack_trace block
+		fprintf( f, "  \"stack_trace\": [\n" );
+		for ( int i = 0; i < frameCount; i++ )
+		{
+			fprintf( f, "    {\n" );
+			fprintf( f, "      \"frame\": %d,\n", i );
+			fprintf( f, "      \"address\": \"0x%08X\",\n", frames[i].addr );
+			fprintf( f, "      \"module\": " );
+			WriteJsonString( f, frames[i].moduleName );
+			fprintf( f, ",\n" );
+			fprintf( f, "      \"module_rva\": \"0x%08X\",\n", frames[i].offset );
+			fprintf( f, "      \"symbol\": " );
+			WriteJsonString( f, frames[i].symbolName );
+			fprintf( f, "\n    }" );
+			if ( i + 1 < frameCount ) fprintf( f, "," );
+			fprintf( f, "\n" );
+		}
+		fprintf( f, "  ],\n" );
+
+		// game block
+		fprintf( f, "  \"game\": {\n" );
+		DWORD runtimeSecs = (GetTickCount() - g_startTick) / 1000;
+		fprintf( f, "    \"runtime_seconds\": %lu,\n", runtimeSecs );
+		fprintf( f, "    \"state\": " );
+		WriteJsonString( f, g_gameState[0] != '\0' ? g_gameState : "unknown" );
+		fprintf( f, "\n  },\n" );
+
+		// os block
+		fprintf( f, "  \"os\": {\n" );
+		fprintf( f, "    \"platform\": " );
+		WriteJsonString( f, "windows" );
+		fprintf( f, ",\n" );
+		fprintf( f, "    \"version\": \"%u.%u.%u\",\n", os.major, os.minor, os.build );
+		fprintf( f, "    \"edition\": " );
+		WriteJsonWString( f, os.edition );
+		fprintf( f, ",\n" );
+		fprintf( f, "    \"is_wine\": %s\n", os.isWine ? "true" : "false" );
+		fprintf( f, "  },\n" );
+
+		// memory block
+		fprintf( f, "  \"memory\": {\n" );
+		fprintf( f, "    \"total_physical_mb\": %llu,\n", mem.totalPhysicalMB );
+		fprintf( f, "    \"available_physical_mb\": %llu,\n", mem.availPhysicalMB );
+		fprintf( f, "    \"process_working_set_mb\": %llu,\n", mem.processWorkingSetMB );
+		fprintf( f, "    \"process_virtual_mb\": %llu,\n", mem.processVirtualMB );
+		fprintf( f, "    \"large_address_aware\": %s\n", mem.largeAddressAware ? "true" : "false" );
+		fprintf( f, "  },\n" );
+
+		// gpu block
+		fprintf( f, "  \"gpu\": {\n" );
+		fprintf( f, "    \"adapter\": " );
+		WriteJsonWString( f, gpu.adapterName );
+		fprintf( f, ",\n" );
+		fprintf( f, "    \"vram_mb\": %llu,\n", gpu.vramMB );
+		fprintf( f, "    \"driver_date\": " );
+		WriteJsonWString( f, gpu.driverDate );
+		fprintf( f, "\n  },\n" );
+
+		// process block
+		fprintf( f, "  \"process\": {\n" );
+		fprintf( f, "    \"pid\": %lu,\n", proc.pid );
+		fprintf( f, "    \"exe_path\": " );
+		WriteJsonWString( f, proc.exePath );
+		fprintf( f, "\n  }\n" );
+
+		fprintf( f, "}\n" );
+		fclose( f );
+	}
+
+	// ------------------------------------------------------------------
+	// Write legacy text crash log (retained for backward compatibility)
+	// ------------------------------------------------------------------
+	static void WriteCrashLog( const wchar_t* path, DWORD exceptionCode, PVOID faultAddr,
+		CONTEXT* ctx, const StackFrame* frames, int frameCount )
+	{
+		FILE* f = nullptr;
+		if ( _wfopen_s( &f, path, L"w" ) != 0 || f == nullptr )
+			return;
+
+		SYSTEMTIME st;
+		GetLocalTime( &st );
+		fprintf( f, "========================================\n" );
+		fprintf( f, "Crash detected at %04d-%02d-%02d %02d:%02d:%02d.%03d\n",
+			st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond, st.wMilliseconds );
+		fprintf( f, "Exception Code: 0x%08X\n", exceptionCode );
+		fprintf( f, "Fault Address:  0x%08X\n", (uint32_t)faultAddr );
+
+		HMODULE hMod = nullptr;
+		if ( GetModuleHandleExA( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)faultAddr, &hMod ) )
+		{
+			char modName[MAX_PATH] = { 0 };
+			GetModuleFileNameA( hMod, modName, MAX_PATH );
+			char* bn = strrchr( modName, '\\' );
+			fprintf( f, "Fault Module:   %s (base: 0x%08X)\n",
+				bn != nullptr ? bn + 1 : modName, (uint32_t)hMod );
+			fprintf( f, "Image RVA:      0x%08X\n", (uint32_t)((uintptr_t)faultAddr - (uintptr_t)hMod) );
+		}
+
+		fprintf( f, "\nRegister State:\n" );
+		fprintf( f, "  EAX: 0x%08X  ECX: 0x%08X  EDX: 0x%08X  EBX: 0x%08X\n",
+			ctx->Eax, ctx->Ecx, ctx->Edx, ctx->Ebx );
+		fprintf( f, "  ESP: 0x%08X  EBP: 0x%08X  ESI: 0x%08X  EDI: 0x%08X\n",
+			ctx->Esp, ctx->Ebp, ctx->Esi, ctx->Edi );
+		fprintf( f, "  EIP: 0x%08X  EFL: 0x%08X\n",
+			ctx->Eip, ctx->EFlags );
+
+		fprintf( f, "\nStack Trace:\n" );
+		for ( int i = 0; i < frameCount; i++ )
+		{
+			if ( frames[i].symbolName[0] != '\0' )
+			{
+				fprintf( f, "  [%02d] 0x%08X  %s!%s+0x%X\n", i, frames[i].addr,
+					frames[i].moduleName, frames[i].symbolName, frames[i].offset );
+			}
+			else
+			{
+				fprintf( f, "  [%02d] 0x%08X  (%s+0x%08X)\n", i, frames[i].addr,
+					frames[i].moduleName, frames[i].offset );
+			}
+		}
+
+		fprintf( f, "========================================\n" );
+		fclose( f );
+	}
+
+	// ------------------------------------------------------------------
+	// Write filtered minidump
+	// ------------------------------------------------------------------
+	static void WriteMiniDump( const wchar_t* path, EXCEPTION_POINTERS* exceptionInfo )
+	{
+		HMODULE hDbgHelp = LoadLibraryA( "dbghelp.dll" );
+		if ( hDbgHelp == nullptr ) return;
+
+		using MiniDumpWriteDump_t = BOOL (WINAPI*)( HANDLE, DWORD, HANDLE, MINIDUMP_TYPE,
+			PMINIDUMP_EXCEPTION_INFORMATION, PMINIDUMP_USER_STREAM_INFORMATION,
+			PMINIDUMP_CALLBACK_INFORMATION );
+		auto pMiniDumpWriteDump = (MiniDumpWriteDump_t)GetProcAddress( hDbgHelp, "MiniDumpWriteDump" );
+		if ( pMiniDumpWriteDump == nullptr )
+		{
+			FreeLibrary( hDbgHelp );
+			return;
+		}
+
+		HANDLE hFile = CreateFileW( path, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr );
+		if ( hFile == INVALID_HANDLE_VALUE )
+		{
+			FreeLibrary( hDbgHelp );
+			return;
+		}
+
+		MINIDUMP_EXCEPTION_INFORMATION mei = {};
+		mei.ThreadId = GetCurrentThreadId();
+		mei.ExceptionPointers = exceptionInfo;
+		mei.ClientPointers = FALSE;
+
+		MINIDUMP_CALLBACK_INFORMATION mci = {};
+		mci.CallbackRoutine = MiniDumpCallback;
+		mci.CallbackParam = nullptr;
+
+		MINIDUMP_TYPE dumpType = (MINIDUMP_TYPE)(MiniDumpWithIndirectlyReferencedMemory |
+			MiniDumpScanMemory);
+
+		pMiniDumpWriteDump( GetCurrentProcess(), GetCurrentProcessId(), hFile, dumpType, &mei, nullptr, &mci );
+
+		CloseHandle( hFile );
+		FreeLibrary( hDbgHelp );
+	}
+
+	// ------------------------------------------------------------------
+	// Vectored Exception Handler
+	// ------------------------------------------------------------------
+	static LONG WINAPI VectoredExceptionHandler( EXCEPTION_POINTERS* ExceptionInfo )
+	{
+		if ( !g_enabled )
+			return EXCEPTION_CONTINUE_SEARCH;
+
+		DWORD code = ExceptionInfo->ExceptionRecord->ExceptionCode;
+		if ( code != EXCEPTION_ACCESS_VIOLATION &&
+			 code != EXCEPTION_ILLEGAL_INSTRUCTION &&
+			 code != EXCEPTION_INT_DIVIDE_BY_ZERO &&
+			 code != EXCEPTION_PRIV_INSTRUCTION )
+		{
+			return EXCEPTION_CONTINUE_SEARCH;
+		}
+
+		PVOID faultAddr = ExceptionInfo->ExceptionRecord->ExceptionAddress;
+		CONTEXT* ctx = ExceptionInfo->ContextRecord;
+
+		// Only log crashes in the game executable or our own module
+		HMODULE hMod = nullptr;
+		if ( !GetModuleHandleExA( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)faultAddr, &hMod ) )
+		{
+			return EXCEPTION_CONTINUE_SEARCH;
+		}
+
+		HMODULE hGame = GetModuleHandle( nullptr );
+		HMODULE hSelf = g_hModule;
+		if ( hMod != hGame && hMod != hSelf )
+		{
+			return EXCEPTION_CONTINUE_SEARCH;
+		}
+
+		// Build base path next to the ASI file
+		wchar_t asiPath[MAX_PATH];
+		if ( GetModuleFileNameW( g_hModule, asiPath, MAX_PATH ) == 0 )
+		{
+			return EXCEPTION_CONTINUE_SEARCH;
+		}
+
+		// Strip filename to get directory
+		wchar_t* lastSlash = wcsrchr( asiPath, L'\\' );
+		if ( lastSlash != nullptr )
+			*(lastSlash + 1) = L'\0';
+
+		// Create crash_reports directory
+		wchar_t reportsDir[MAX_PATH];
+		swprintf_s( reportsDir, L"%scrash_reports\\", asiPath );
+		EnsureDirectory( reportsDir );
+
+		// Create timestamped subdirectory
+		SYSTEMTIME st;
+		GetLocalTime( &st );
+		wchar_t crashDir[MAX_PATH];
+		swprintf_s( crashDir, L"%scrash_%04d-%02d-%02d_%02d%02d%02d\\",
+			reportsDir, st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond );
+		EnsureDirectory( crashDir );
+
+		// Collect system info
+		OSInfo osInfo;
+		MemoryInfo memInfo;
+		GPUInfo gpuInfo;
+		ProcessInfo procInfo;
+		CollectOSInfo( osInfo );
+		CollectMemoryInfo( memInfo, true );
+		CollectGPUInfo( gpuInfo );
+		CollectProcessInfo( procInfo );
+
+		// Capture stack trace
+		StackFrame frames[64];
+		int frameCount = CaptureStackTrace( ctx, frames, 64 );
+
+		// Write JSON report
+		wchar_t jsonPath[MAX_PATH];
+		swprintf_s( jsonPath, L"%scrash.json", crashDir );
+		WriteCrashJson( jsonPath, code, faultAddr, ctx, frames, frameCount, osInfo, memInfo, gpuInfo, procInfo );
+
+		// Write legacy text log
+		wchar_t logPath[MAX_PATH];
+		swprintf_s( logPath, L"%scrash.txt", crashDir );
+		WriteCrashLog( logPath, code, faultAddr, ctx, frames, frameCount );
+
+		// Write filtered minidump
+		wchar_t dmpPath[MAX_PATH];
+		swprintf_s( dmpPath, L"%scrash.dmp", crashDir );
+		WriteMiniDump( dmpPath, ExceptionInfo );
+
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+
+	// ------------------------------------------------------------------
+	// Public API
+	// ------------------------------------------------------------------
+	void Install( HINSTANCE hModule )
+	{
+		if ( _InterlockedCompareExchange( &g_installed, 1, 0 ) != 0 )
+			return;
+
+		g_hModule = hModule;
+		g_startTick = GetTickCount();
+		AddVectoredExceptionHandler( 1, VectoredExceptionHandler );
+	}
+}

--- a/SilentPatchBully/CrashReporter/CrashReporter.h
+++ b/SilentPatchBully/CrashReporter/CrashReporter.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <windows.h>
+
+namespace CrashReporter
+{
+	// Install the VEH crash reporter. Call once during DLL init.
+	void Install( HINSTANCE hModule );
+
+	// Enable/disable crash reporting (checked at crash time, not during gameplay)
+	void SetEnabled( bool enable );
+	bool IsEnabled();
+
+	// Set the game state string for crash context (e.g. "Chapter 2 - Loading").
+	// Call from hook points if you want richer context. Safe to call from any thread.
+	void SetGameState( const char* state );
+}

--- a/SilentPatchBully/CrashReporter/SystemInfo.cpp
+++ b/SilentPatchBully/CrashReporter/SystemInfo.cpp
@@ -1,0 +1,227 @@
+#include "SystemInfo.h"
+
+#include <stdio.h>
+#include <wchar.h>
+#include <psapi.h>
+#include <shlwapi.h>
+#pragma comment(lib, "psapi.lib")
+#pragma comment(lib, "shlwapi.lib")
+
+namespace CrashReporter
+{
+	void CollectOSInfo( OSInfo& out )
+	{
+		memset( &out, 0, sizeof(out) );
+
+		RTL_OSVERSIONINFOW osvi = { sizeof(osvi) };
+		// Dynamically load RtlGetVersion to avoid linker dependency on ntdll.lib (needed for XP SDK)
+		using RtlGetVersion_t = LONG (WINAPI*)( PRTL_OSVERSIONINFOW );
+		auto pRtlGetVersion = (RtlGetVersion_t)GetProcAddress( GetModuleHandleW( L"ntdll.dll" ), "RtlGetVersion" );
+		if ( pRtlGetVersion != nullptr && pRtlGetVersion( &osvi ) == 0 )
+		{
+			out.major = osvi.dwMajorVersion;
+			out.minor = osvi.dwMinorVersion;
+			out.build = osvi.dwBuildNumber;
+		}
+
+		// Detect Wine
+		HMODULE hNtdll = GetModuleHandleW( L"ntdll.dll" );
+		if ( hNtdll != nullptr )
+		{
+			out.isWine = (GetProcAddress( hNtdll, "wine_get_version" ) != nullptr);
+		}
+
+		// Build a friendly edition string
+		if ( out.isWine )
+		{
+			wcscpy_s( out.edition, L"Wine/Proton" );
+		}
+		else if ( out.major == 10 && out.minor == 0 )
+		{
+			if ( out.build >= 22000 )
+				wcscpy_s( out.edition, L"Windows 11" );
+			else
+				wcscpy_s( out.edition, L"Windows 10" );
+		}
+		else if ( out.major == 6 && out.minor == 3 )
+		{
+			wcscpy_s( out.edition, L"Windows 8.1" );
+		}
+		else if ( out.major == 6 && out.minor == 2 )
+		{
+			wcscpy_s( out.edition, L"Windows 8" );
+		}
+		else if ( out.major == 6 && out.minor == 1 )
+		{
+			wcscpy_s( out.edition, L"Windows 7" );
+		}
+		else if ( out.major == 6 && out.minor == 0 )
+		{
+			wcscpy_s( out.edition, L"Windows Vista" );
+		}
+		else if ( out.major == 5 && out.minor == 1 )
+		{
+			wcscpy_s( out.edition, L"Windows XP" );
+		}
+		else
+		{
+			swprintf_s( out.edition, L"Windows %u.%u", out.major, out.minor );
+		}
+	}
+
+	void CollectMemoryInfo( MemoryInfo& out, bool checkLAA )
+	{
+		memset( &out, 0, sizeof(out) );
+
+		MEMORYSTATUSEX memStatus = { sizeof(memStatus) };
+		if ( GlobalMemoryStatusEx( &memStatus ) )
+		{
+			out.totalPhysicalMB = memStatus.ullTotalPhys / (1024 * 1024);
+			out.availPhysicalMB = memStatus.ullAvailPhys / (1024 * 1024);
+		}
+
+		PROCESS_MEMORY_COUNTERS pmc = {};
+		if ( GetProcessMemoryInfo( GetCurrentProcess(), &pmc, sizeof(pmc) ) )
+		{
+			out.processWorkingSetMB = pmc.WorkingSetSize / (1024 * 1024);
+			out.processVirtualMB = pmc.PagefileUsage / (1024 * 1024);
+		}
+
+		if ( checkLAA )
+		{
+			out.largeAddressAware = IsLargeAddressAware( GetModuleHandle( nullptr ) );
+		}
+	}
+
+	void CollectGPUInfo( GPUInfo& out )
+	{
+		memset( &out, 0, sizeof(out) );
+
+		// Try DXGI first (most reliable on Win7+)
+		HMODULE hDxgi = LoadLibraryW( L"dxgi.dll" );
+		if ( hDxgi != nullptr )
+		{
+			using CreateDXGIFactory1_t = HRESULT (WINAPI*)( REFIID, void** );
+			auto pCreateDXGIFactory1 = (CreateDXGIFactory1_t)GetProcAddress( hDxgi, "CreateDXGIFactory1" );
+			if ( pCreateDXGIFactory1 != nullptr )
+			{
+				struct IDXGIAdapter;
+				struct IDXGIFactory;
+				const IID IID_IDXGIFactory1 = { 0x770aae78, 0xf26f, 0x4dba, { 0xa8, 0x29, 0x25, 0x3c, 0x83, 0x31, 0x8b, 0xf7 } };
+				IDXGIFactory* pFactory = nullptr;
+				if ( SUCCEEDED( pCreateDXGIFactory1( IID_IDXGIFactory1, (void**)&pFactory ) ) && pFactory != nullptr )
+				{
+					struct IDXGIAdapter1;
+					const IID IID_IDXGIAdapter1 = { 0x29038f61, 0x3839, 0x4626, { 0x91, 0xfd, 0x08, 0x68, 0x79, 0x01, 0x1a, 0x05 } };
+					void* pAdapter = nullptr;
+					// Use vtable call: EnumAdapters1 is at index 7 in IDXGIFactory1
+					using EnumAdapters1_t = HRESULT (__stdcall*)( void*, UINT, void** );
+					void** vtable = *(void***)pFactory;
+					auto pEnumAdapters1 = (EnumAdapters1_t)vtable[7];
+					if ( SUCCEEDED( pEnumAdapters1( pFactory, 0, &pAdapter ) ) && pAdapter != nullptr )
+					{
+						// IDXGIAdapter1::GetDesc1 at index 10
+						struct DXGI_ADAPTER_DESC1
+						{
+							WCHAR Description[128];
+							UINT VendorId;
+							UINT DeviceId;
+							UINT SubSysId;
+							UINT Revision;
+							SIZE_T DedicatedVideoMemory;
+							SIZE_T DedicatedSystemMemory;
+							SIZE_T SharedSystemMemory;
+							LUID AdapterLuid;
+							UINT Flags;
+						};
+						using GetDesc1_t = HRESULT (__stdcall*)( void*, DXGI_ADAPTER_DESC1* );
+						void** adapterVtable = *(void***)pAdapter;
+						auto pGetDesc1 = (GetDesc1_t)adapterVtable[10];
+						DXGI_ADAPTER_DESC1 desc = {};
+						if ( SUCCEEDED( pGetDesc1( pAdapter, &desc ) ) )
+						{
+							wcscpy_s( out.adapterName, desc.Description );
+							out.vramMB = desc.DedicatedVideoMemory / (1024 * 1024);
+						}
+						// Release adapter
+						using Release_t = ULONG (__stdcall*)( void* );
+						auto pRelease = (Release_t)adapterVtable[2];
+						pRelease( pAdapter );
+					}
+					// Release factory
+					using Release_t = ULONG (__stdcall*)( void* );
+					auto pRelease = (Release_t)vtable[2];
+					pRelease( pFactory );
+				}
+			}
+			FreeLibrary( hDxgi );
+		}
+
+		// Fallback to GDI display device
+		if ( out.adapterName[0] == L'\0' )
+		{
+			DISPLAY_DEVICEW dd = { sizeof(dd) };
+			if ( EnumDisplayDevicesW( nullptr, 0, &dd, 0 ) )
+			{
+				wcscpy_s( out.adapterName, dd.DeviceString );
+			}
+		}
+
+		// Driver date from registry (best effort)
+		HKEY hKey;
+		if ( RegOpenKeyExW( HKEY_LOCAL_MACHINE,
+			L"SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}",
+			0, KEY_READ, &hKey ) == ERROR_SUCCESS )
+		{
+			WCHAR subkeyName[256];
+			DWORD index = 0, nameLen = 256;
+			while ( RegEnumKeyExW( hKey, index++, subkeyName, &nameLen, nullptr, nullptr, nullptr, nullptr ) == ERROR_SUCCESS )
+			{
+				nameLen = 256;
+				HKEY hSubKey;
+				if ( RegOpenKeyExW( hKey, subkeyName, 0, KEY_READ, &hSubKey ) == ERROR_SUCCESS )
+				{
+					WCHAR driverDesc[256] = {};
+					DWORD size = sizeof(driverDesc);
+					if ( RegQueryValueExW( hSubKey, L"DriverDesc", nullptr, nullptr, (LPBYTE)driverDesc, &size ) == ERROR_SUCCESS )
+					{
+						// Simple substring match
+						if ( wcsstr( out.adapterName, driverDesc ) != nullptr || wcsstr( driverDesc, out.adapterName ) != nullptr )
+						{
+							WCHAR driverDate[32] = {};
+							size = sizeof(driverDate);
+							if ( RegQueryValueExW( hSubKey, L"DriverDate", nullptr, nullptr, (LPBYTE)driverDate, &size ) == ERROR_SUCCESS )
+							{
+								wcscpy_s( out.driverDate, driverDate );
+							}
+							RegCloseKey( hSubKey );
+							break;
+						}
+					}
+					RegCloseKey( hSubKey );
+				}
+			}
+			RegCloseKey( hKey );
+		}
+	}
+
+	void CollectProcessInfo( ProcessInfo& out )
+	{
+		memset( &out, 0, sizeof(out) );
+		out.pid = GetCurrentProcessId();
+		GetModuleFileNameW( nullptr, out.exePath, MAX_PATH );
+	}
+
+	bool IsLargeAddressAware( HMODULE hModule )
+	{
+		if ( hModule == nullptr ) return false;
+
+		auto* dosHeader = (PIMAGE_DOS_HEADER)hModule;
+		if ( dosHeader->e_magic != IMAGE_DOS_SIGNATURE ) return false;
+
+		auto* ntHeader = (PIMAGE_NT_HEADERS)((uintptr_t)hModule + dosHeader->e_lfanew);
+		if ( ntHeader->Signature != IMAGE_NT_SIGNATURE ) return false;
+
+		return (ntHeader->FileHeader.Characteristics & IMAGE_FILE_LARGE_ADDRESS_AWARE) != 0;
+	}
+}

--- a/SilentPatchBully/CrashReporter/SystemInfo.cpp
+++ b/SilentPatchBully/CrashReporter/SystemInfo.cpp
@@ -93,11 +93,92 @@ namespace CrashReporter
 		}
 	}
 
+	// ------------------------------------------------------------------------
+	// GPU classification helpers
+	// ------------------------------------------------------------------------
+	static bool IsAdapterNameKnown( const GPUInfo& info, const wchar_t* name )
+	{
+		for ( uint32_t i = 0; i < info.adapterCount; i++ )
+		{
+			if ( wcsstr( info.adapters[i].name, name ) != nullptr ||
+			     wcsstr( name, info.adapters[i].name ) != nullptr )
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	static bool ClassifyGpuAsIntegrated( const wchar_t* name, uint32_t vendorId )
+	{
+		// Intel: overwhelmingly integrated. Intel Arc is the rare discrete exception.
+		if ( vendorId == 0x8086 )
+		{
+			if ( wcsstr( name, L"Arc" ) != nullptr )
+				return false;
+			return true;
+		}
+
+		// NVIDIA does not make x86 integrated GPUs (Tegra is ARM-only).
+		if ( vendorId == 0x10DE )
+			return false;
+
+		// AMD: APUs (integrated) usually contain "Radeon Graphics" without a model number.
+		//      Discrete cards have model series like RX, HD, R9, R7, etc.
+		if ( vendorId == 0x1002 )
+		{
+			if ( wcsstr( name, L"Radeon Graphics" ) != nullptr &&
+			     wcsstr( name, L"RX" ) == nullptr )
+			{
+				return true;
+			}
+			return false;
+		}
+
+		// Unknown vendor: guess by name heuristics
+		if ( wcsstr( name, L"Intel" ) != nullptr && wcsstr( name, L"Arc" ) == nullptr )
+			return true;
+		if ( wcsstr( name, L"NVIDIA" ) != nullptr || wcsstr( name, L"GeForce" ) != nullptr )
+			return false;
+		if ( wcsstr( name, L"AMD" ) != nullptr || wcsstr( name, L"ATI" ) != nullptr || wcsstr( name, L"Radeon" ) != nullptr )
+		{
+			if ( wcsstr( name, L"Radeon Graphics" ) != nullptr && wcsstr( name, L"RX" ) == nullptr )
+				return true;
+			return false;
+		}
+
+		return false;
+	}
+
+	// Parse a PCI HardwareID/MatchingDeviceId string for the vendor ID.
+	// Expected format: PCI\VEN_10DE&DEV_XXXX...
+	static uint32_t ParseVendorIdFromPciString( const wchar_t* id )
+	{
+		if ( id == nullptr ) return 0;
+		const wchar_t* ven = wcsstr( id, L"VEN_" );
+		if ( ven != nullptr )
+		{
+			wchar_t* end = nullptr;
+			unsigned long val = wcstoul( ven + 4, &end, 16 );
+			if ( end != ven + 4 ) return static_cast<uint32_t>( val );
+		}
+		return 0;
+	}
+
+	// ------------------------------------------------------------------------
+	// Layered GPU detection:
+	//   1) DXGI          – best detail for active adapters (Win7+)
+	//   2) Registry      – catches *all* installed display adapters, including
+	//                      hidden Optimus dGPUs that DXGI omits (Win2000+)
+	//   3) EnumDisplayDevices – legacy GDI fallback (Win2000+)
+	// ------------------------------------------------------------------------
 	void CollectGPUInfo( GPUInfo& out )
 	{
 		memset( &out, 0, sizeof(out) );
 
-		// Try DXGI first (most reliable on Win7+)
+		// ----------------------------------------------------------------
+		// Layer 1: DXGI
+		// ----------------------------------------------------------------
 		HMODULE hDxgi = LoadLibraryW( L"dxgi.dll" );
 		if ( hDxgi != nullptr )
 		{
@@ -105,103 +186,206 @@ namespace CrashReporter
 			auto pCreateDXGIFactory1 = (CreateDXGIFactory1_t)GetProcAddress( hDxgi, "CreateDXGIFactory1" );
 			if ( pCreateDXGIFactory1 != nullptr )
 			{
-				struct IDXGIAdapter;
-				struct IDXGIFactory;
 				const IID IID_IDXGIFactory1 = { 0x770aae78, 0xf26f, 0x4dba, { 0xa8, 0x29, 0x25, 0x3c, 0x83, 0x31, 0x8b, 0xf7 } };
-				IDXGIFactory* pFactory = nullptr;
+				void* pFactory = nullptr;
 				if ( SUCCEEDED( pCreateDXGIFactory1( IID_IDXGIFactory1, (void**)&pFactory ) ) && pFactory != nullptr )
 				{
-					struct IDXGIAdapter1;
-					const IID IID_IDXGIAdapter1 = { 0x29038f61, 0x3839, 0x4626, { 0x91, 0xfd, 0x08, 0x68, 0x79, 0x01, 0x1a, 0x05 } };
-					void* pAdapter = nullptr;
-					// Use vtable call: EnumAdapters1 is at index 7 in IDXGIFactory1
+					struct DXGI_ADAPTER_DESC1
+					{
+						WCHAR Description[128];
+						UINT VendorId;
+						UINT DeviceId;
+						UINT SubSysId;
+						UINT Revision;
+						SIZE_T DedicatedVideoMemory;
+						SIZE_T DedicatedSystemMemory;
+						SIZE_T SharedSystemMemory;
+						LUID AdapterLuid;
+						UINT Flags;
+					};
+
 					using EnumAdapters1_t = HRESULT (__stdcall*)( void*, UINT, void** );
+					using GetDesc1_t = HRESULT (__stdcall*)( void*, DXGI_ADAPTER_DESC1* );
+					using Release_t = ULONG (__stdcall*)( void* );
+
 					void** vtable = *(void***)pFactory;
 					auto pEnumAdapters1 = (EnumAdapters1_t)vtable[7];
-					if ( SUCCEEDED( pEnumAdapters1( pFactory, 0, &pAdapter ) ) && pAdapter != nullptr )
+
+					for ( UINT adapterIndex = 0; adapterIndex < MAX_GPU_ADAPTERS; adapterIndex++ )
 					{
-						// IDXGIAdapter1::GetDesc1 at index 10
-						struct DXGI_ADAPTER_DESC1
-						{
-							WCHAR Description[128];
-							UINT VendorId;
-							UINT DeviceId;
-							UINT SubSysId;
-							UINT Revision;
-							SIZE_T DedicatedVideoMemory;
-							SIZE_T DedicatedSystemMemory;
-							SIZE_T SharedSystemMemory;
-							LUID AdapterLuid;
-							UINT Flags;
-						};
-						using GetDesc1_t = HRESULT (__stdcall*)( void*, DXGI_ADAPTER_DESC1* );
+						void* pAdapter = nullptr;
+						HRESULT hr = pEnumAdapters1( pFactory, adapterIndex, &pAdapter );
+						if ( FAILED( hr ) || pAdapter == nullptr )
+							break;
+
 						void** adapterVtable = *(void***)pAdapter;
 						auto pGetDesc1 = (GetDesc1_t)adapterVtable[10];
+						auto pRelease  = (Release_t)adapterVtable[2];
+
 						DXGI_ADAPTER_DESC1 desc = {};
 						if ( SUCCEEDED( pGetDesc1( pAdapter, &desc ) ) )
 						{
-							wcscpy_s( out.adapterName, desc.Description );
-							out.vramMB = desc.DedicatedVideoMemory / (1024 * 1024);
+							GPUAdapter& gpu = out.adapters[out.adapterCount++];
+							wcscpy_s( gpu.name, desc.Description );
+							gpu.vramMB    = desc.DedicatedVideoMemory / (1024 * 1024);
+							gpu.sharedMB  = desc.SharedSystemMemory / (1024 * 1024);
+							gpu.isIntegrated = ClassifyGpuAsIntegrated( desc.Description, desc.VendorId );
+
+							// Intel iGPUs sometimes report 0 shared memory. Backfill from system RAM.
+							if ( gpu.isIntegrated && gpu.sharedMB == 0 )
+							{
+								MEMORYSTATUSEX ms = { sizeof(ms) };
+								if ( GlobalMemoryStatusEx( &ms ) )
+									gpu.sharedMB = ms.ullTotalPhys / (1024 * 1024);
+							}
 						}
-						// Release adapter
-						using Release_t = ULONG (__stdcall*)( void* );
-						auto pRelease = (Release_t)adapterVtable[2];
 						pRelease( pAdapter );
 					}
-					// Release factory
-					using Release_t = ULONG (__stdcall*)( void* );
-					auto pRelease = (Release_t)vtable[2];
-					pRelease( pFactory );
+
+					auto pReleaseFactory = (Release_t)vtable[2];
+					pReleaseFactory( pFactory );
 				}
 			}
 			FreeLibrary( hDxgi );
 		}
 
-		// Fallback to GDI display device
-		if ( out.adapterName[0] == L'\0' )
+		// ----------------------------------------------------------------
+		// Layer 2: Registry scan of the Display Class GUID.
+		// This enumerates *every* installed display adapter driver,
+		// including Optimus dGPUs that are hidden from DXGI/GDI.
+		// ----------------------------------------------------------------
 		{
-			DISPLAY_DEVICEW dd = { sizeof(dd) };
-			if ( EnumDisplayDevicesW( nullptr, 0, &dd, 0 ) )
+			HKEY hKey;
+			if ( RegOpenKeyExW( HKEY_LOCAL_MACHINE,
+				L"SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}",
+				0, KEY_READ, &hKey ) == ERROR_SUCCESS )
 			{
-				wcscpy_s( out.adapterName, dd.DeviceString );
+				WCHAR subkeyName[256];
+				DWORD index = 0, nameLen = 256;
+				while ( RegEnumKeyExW( hKey, index++, subkeyName, &nameLen, nullptr, nullptr, nullptr, nullptr ) == ERROR_SUCCESS )
+				{
+					nameLen = 256;
+					HKEY hSubKey;
+					if ( RegOpenKeyExW( hKey, subkeyName, 0, KEY_READ, &hSubKey ) != ERROR_SUCCESS )
+						continue;
+
+					WCHAR driverDesc[256] = {};
+					DWORD size = sizeof(driverDesc);
+					bool hasDesc = (RegQueryValueExW( hSubKey, L"DriverDesc", nullptr, nullptr, (LPBYTE)driverDesc, &size ) == ERROR_SUCCESS);
+
+					// Parse vendor from MatchingDeviceId (PCI\VEN_xxxx&DEV_xxxx...)
+					uint32_t vendorId = 0;
+					WCHAR matchId[256] = {};
+					size = sizeof(matchId);
+					if ( RegQueryValueExW( hSubKey, L"MatchingDeviceId", nullptr, nullptr, (LPBYTE)matchId, &size ) == ERROR_SUCCESS )
+					{
+						vendorId = ParseVendorIdFromPciString( matchId );
+					}
+
+					// Try to read VRAM from HardwareInformation.qwMemorySize (binary QWORD)
+					uint64_t regVramMB = 0;
+					DWORD qwType = 0;
+					ULONGLONG qwMem = 0;
+					DWORD qwSize = sizeof(qwMem);
+					if ( RegQueryValueExW( hSubKey, L"HardwareInformation.qwMemorySize", nullptr, &qwType, (LPBYTE)&qwMem, &qwSize ) == ERROR_SUCCESS )
+					{
+						if ( qwType == REG_BINARY && qwSize == sizeof(ULONGLONG) )
+							regVramMB = qwMem / (1024 * 1024);
+						else if ( qwType == REG_QWORD )
+							regVramMB = qwMem / (1024 * 1024);
+					}
+
+					// If we have a name and it is not already known, add it.
+					if ( hasDesc && driverDesc[0] != L'\0' &&
+					     out.adapterCount < MAX_GPU_ADAPTERS &&
+					     !IsAdapterNameKnown( out, driverDesc ) )
+					{
+						GPUAdapter& gpu = out.adapters[out.adapterCount++];
+						wcscpy_s( gpu.name, driverDesc );
+						gpu.vramMB   = regVramMB;
+						gpu.sharedMB = 0;
+						gpu.isIntegrated = ClassifyGpuAsIntegrated( driverDesc, vendorId );
+					}
+
+					RegCloseKey( hSubKey );
+				}
+				RegCloseKey( hKey );
 			}
 		}
 
-		// Driver date from registry (best effort)
-		HKEY hKey;
-		if ( RegOpenKeyExW( HKEY_LOCAL_MACHINE,
-			L"SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}",
-			0, KEY_READ, &hKey ) == ERROR_SUCCESS )
+		// ----------------------------------------------------------------
+		// Layer 3: EnumDisplayDevices (legacy fallback)
+		// ----------------------------------------------------------------
 		{
-			WCHAR subkeyName[256];
-			DWORD index = 0, nameLen = 256;
-			while ( RegEnumKeyExW( hKey, index++, subkeyName, &nameLen, nullptr, nullptr, nullptr, nullptr ) == ERROR_SUCCESS )
+			DISPLAY_DEVICEW dd = { sizeof(dd) };
+			for ( DWORD deviceIndex = 0; deviceIndex < MAX_GPU_ADAPTERS; deviceIndex++ )
 			{
-				nameLen = 256;
-				HKEY hSubKey;
-				if ( RegOpenKeyExW( hKey, subkeyName, 0, KEY_READ, &hSubKey ) == ERROR_SUCCESS )
-				{
-					WCHAR driverDesc[256] = {};
-					DWORD size = sizeof(driverDesc);
-					if ( RegQueryValueExW( hSubKey, L"DriverDesc", nullptr, nullptr, (LPBYTE)driverDesc, &size ) == ERROR_SUCCESS )
-					{
-						// Simple substring match
-						if ( wcsstr( out.adapterName, driverDesc ) != nullptr || wcsstr( driverDesc, out.adapterName ) != nullptr )
-						{
-							WCHAR driverDate[32] = {};
-							size = sizeof(driverDate);
-							if ( RegQueryValueExW( hSubKey, L"DriverDate", nullptr, nullptr, (LPBYTE)driverDate, &size ) == ERROR_SUCCESS )
-							{
-								wcscpy_s( out.driverDate, driverDate );
-							}
-							RegCloseKey( hSubKey );
-							break;
-						}
-					}
-					RegCloseKey( hSubKey );
-				}
+				if ( !EnumDisplayDevicesW( nullptr, deviceIndex, &dd, 0 ) )
+					break;
+				if ( dd.StateFlags & DISPLAY_DEVICE_MIRRORING_DRIVER )
+					continue;
+				if ( out.adapterCount >= MAX_GPU_ADAPTERS )
+					break;
+				if ( IsAdapterNameKnown( out, dd.DeviceString ) )
+					continue;
+
+				GPUAdapter& gpu = out.adapters[out.adapterCount++];
+				wcscpy_s( gpu.name, dd.DeviceString );
+				gpu.vramMB   = 0;
+				gpu.sharedMB = 0;
+				gpu.isIntegrated = ClassifyGpuAsIntegrated( dd.DeviceString, 0 );
 			}
-			RegCloseKey( hKey );
+		}
+
+		// ----------------------------------------------------------------
+		// Driver date: match against any adapter name
+		// ----------------------------------------------------------------
+		if ( out.adapterCount > 0 )
+		{
+			HKEY hKey;
+			if ( RegOpenKeyExW( HKEY_LOCAL_MACHINE,
+				L"SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}",
+				0, KEY_READ, &hKey ) == ERROR_SUCCESS )
+			{
+				WCHAR subkeyName[256];
+				DWORD index = 0, nameLen = 256;
+				while ( RegEnumKeyExW( hKey, index++, subkeyName, &nameLen, nullptr, nullptr, nullptr, nullptr ) == ERROR_SUCCESS )
+				{
+					nameLen = 256;
+					HKEY hSubKey;
+					if ( RegOpenKeyExW( hKey, subkeyName, 0, KEY_READ, &hSubKey ) == ERROR_SUCCESS )
+					{
+						WCHAR driverDesc[256] = {};
+						DWORD size = sizeof(driverDesc);
+						if ( RegQueryValueExW( hSubKey, L"DriverDesc", nullptr, nullptr, (LPBYTE)driverDesc, &size ) == ERROR_SUCCESS )
+						{
+							bool matched = false;
+							for ( uint32_t i = 0; i < out.adapterCount; i++ )
+							{
+								if ( wcsstr( out.adapters[i].name, driverDesc ) != nullptr ||
+								     wcsstr( driverDesc, out.adapters[i].name ) != nullptr )
+								{
+									matched = true;
+									break;
+								}
+							}
+							if ( matched )
+							{
+								WCHAR driverDate[32] = {};
+								size = sizeof(driverDate);
+								if ( RegQueryValueExW( hSubKey, L"DriverDate", nullptr, nullptr, (LPBYTE)driverDate, &size ) == ERROR_SUCCESS )
+								{
+									wcscpy_s( out.driverDate, driverDate );
+								}
+								RegCloseKey( hSubKey );
+								break;
+							}
+						}
+						RegCloseKey( hSubKey );
+					}
+				}
+				RegCloseKey( hKey );
+			}
 		}
 	}
 

--- a/SilentPatchBully/CrashReporter/SystemInfo.h
+++ b/SilentPatchBully/CrashReporter/SystemInfo.h
@@ -23,10 +23,20 @@ namespace CrashReporter
 		bool largeAddressAware;
 	};
 
+	struct GPUAdapter
+	{
+		wchar_t name[128];
+		uint64_t vramMB;
+		uint64_t sharedMB;
+		bool isIntegrated;
+	};
+
+	static constexpr size_t MAX_GPU_ADAPTERS = 4;
+
 	struct GPUInfo
 	{
-		wchar_t adapterName[128];
-		uint64_t vramMB;
+		GPUAdapter adapters[MAX_GPU_ADAPTERS];
+		uint32_t adapterCount;
 		wchar_t driverDate[32];
 	};
 

--- a/SilentPatchBully/CrashReporter/SystemInfo.h
+++ b/SilentPatchBully/CrashReporter/SystemInfo.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <windows.h>
+#include <cstdint>
+
+namespace CrashReporter
+{
+	struct OSInfo
+	{
+		wchar_t edition[128];
+		uint32_t major;
+		uint32_t minor;
+		uint32_t build;
+		bool isWine;
+	};
+
+	struct MemoryInfo
+	{
+		uint64_t totalPhysicalMB;
+		uint64_t availPhysicalMB;
+		uint64_t processWorkingSetMB;
+		uint64_t processVirtualMB;
+		bool largeAddressAware;
+	};
+
+	struct GPUInfo
+	{
+		wchar_t adapterName[128];
+		uint64_t vramMB;
+		wchar_t driverDate[32];
+	};
+
+	struct ProcessInfo
+	{
+		uint32_t pid;
+		uint32_t runtimeSeconds;
+		wchar_t exePath[MAX_PATH];
+	};
+
+	void CollectOSInfo( OSInfo& out );
+	void CollectMemoryInfo( MemoryInfo& out, bool checkLAA );
+	void CollectGPUInfo( GPUInfo& out );
+	void CollectProcessInfo( ProcessInfo& out );
+	bool IsLargeAddressAware( HMODULE hModule );
+}

--- a/SilentPatchBully/SilentPatchBully.cpp
+++ b/SilentPatchBully/SilentPatchBully.cpp
@@ -1041,13 +1041,23 @@ static void InstallHooks()
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
-	UNREFERENCED_PARAMETER(hinstDLL);
 	UNREFERENCED_PARAMETER(lpvReserved);
 
 	if ( fdwReason == DLL_PROCESS_ATTACH )
 	{
 		hDLLModule = hinstDLL;
-		CrashReporter::Install( hinstDLL );
+
+		// Check if the user has opted out of crash telemetry.
+		// INI setting: [SilentPatch] CrashReporter=1 (default, enabled) or 0 (disabled)
+		wchar_t wcIniPath[MAX_PATH];
+		GetModuleFileNameW( hinstDLL, wcIniPath, _countof(wcIniPath) - 3 );
+		PathRenameExtensionW( wcIniPath, L".ini" );
+		int crashReporterOptIn = GetPrivateProfileIntW( L"SilentPatch", L"CrashReporter", 1, wcIniPath );
+
+		if ( crashReporterOptIn != 0 )
+		{
+			CrashReporter::Install( hinstDLL );
+		}
 	}
 	return TRUE;
 }

--- a/SilentPatchBully/SilentPatchBully.cpp
+++ b/SilentPatchBully/SilentPatchBully.cpp
@@ -7,6 +7,7 @@
 #include <windows.h>
 #include "Utils/MemoryMgr.h"
 #include "PoolsBully.h"
+#include "CrashReporter/CrashReporter.h"
 
 #include <cassert>
 
@@ -1046,6 +1047,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 	if ( fdwReason == DLL_PROCESS_ATTACH )
 	{
 		hDLLModule = hinstDLL;
+		CrashReporter::Install( hinstDLL );
 	}
 	return TRUE;
 }

--- a/SilentPatchBully/SilentPatchBully.vcxproj
+++ b/SilentPatchBully/SilentPatchBully.vcxproj
@@ -16,10 +16,14 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="SilentPatchBully.cpp" />
+    <ClCompile Include="CrashReporter\CrashReporter.cpp" />
+    <ClCompile Include="CrashReporter\SystemInfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ModUtils\MemoryMgr.h" />
     <ClInclude Include="PoolsBully.h" />
+    <ClInclude Include="CrashReporter\CrashReporter.h" />
+    <ClInclude Include="CrashReporter\SystemInfo.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="SilentPatch.rc" />

--- a/SilentPatchBully/SilentPatchBully.vcxproj.filters
+++ b/SilentPatchBully/SilentPatchBully.vcxproj.filters
@@ -21,6 +21,12 @@
     <ClCompile Include="SilentPatchBully.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="CrashReporter\CrashReporter.cpp">
+      <Filter>Source Files\CrashReporter</Filter>
+    </ClCompile>
+    <ClCompile Include="CrashReporter\SystemInfo.cpp">
+      <Filter>Source Files\CrashReporter</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="PoolsBully.h">
@@ -29,6 +35,20 @@
     <ClInclude Include="ModUtils\MemoryMgr.h">
       <Filter>Header Files\Utils</Filter>
     </ClInclude>
+    <ClInclude Include="CrashReporter\CrashReporter.h">
+      <Filter>Header Files\CrashReporter</Filter>
+    </ClInclude>
+    <ClInclude Include="CrashReporter\SystemInfo.h">
+      <Filter>Header Files\CrashReporter</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Source Files\CrashReporter">
+      <UniqueIdentifier>{a1b2c3d4-e5f6-7890-abcd-ef1234567890}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\CrashReporter">
+      <UniqueIdentifier>{b2c3d4e5-f6a7-8901-bcde-f12345678901}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="SilentPatch.rc">


### PR DESCRIPTION
Hello, 

This is my first pull request and I would like to support your Silent Patch by helping others with their crashes. To my understanding, I found that most users are experiencing bugs from the game itself, **not** your patch. So I would like to improve or at least mitigate some of the users' bugs by adding defensive measures and improvements in the patch that take account into these unknown in-game crashes.

The patch is stable but I feel like we should handle the other many issues that others are experiencing outside of the patch. So I added a crash logger VEH-Based crash reporting & telemetry diagnostics, and it being optional (So users can opt-out when they feel the telemetry is unneeded) in the `.ini` file under:

```
; Enable crash reporter telemetry (JSON + minidump + text log)
; Set to 0 to opt out of crash data collection
; Default - 1
CrashReporter=1  // "0" being to not have telemetry
```

For complete transparency, I've coded this with the help of AI assistants, but the implementation idea is mine alone and I've done extensive research online on how crash loggers work, especially modern ones. I've also tested it extensively with intentional crashes I've made (Not included in the PR) and it works just fine, generating a `crash_reports` in the game directory with the data we need to find the bugs and potentially patch it with the Silent Patch.

The reason for this PR being that I find it's unreasonable for players to upload a 35+ Megabytes of crash reports and having them upload via Google Drive. I think it's much more easier to get the crash logs through a JSON file and some data that actually counts, thus reducing the file size needed to around 250 KB, less than 1-2 MB at least.

I want to help close issues from others, but the DMP files don't last long in Google Drive, so I wanted to implement as more lighter system for getting data from the user's crashes.

If there are any contentions on your side, I'd like to hear it. This is my first ever pull request and I'd like to learn as much as possible. I love playing Bully when I was younger and using your patch really helps my game back then. I only wish to help, but if you have a problem with the unnecessary telemetry or me using AI, I can fully understand that.

If this is merged, I want to continue helping as many users as possible with this new crash logger, that way, others can simply compress their  `crash_reports` folder in a zip file (or paste their JSON File and `.txt` file), comfortably uploading them to the issues in this repo without having to use an external file uploader, and makes it easier to debug and track down the issue without having to use WinDbg or other heavy tools. Although I still do use the `.dmp` file format when logging the crash, but it's only around 250-500KB in size, and I use [minidump](https://github.com/skelsec/minidump) to analyze and parse all the crash data we need.