### PR TITLE
Add compatibility workaround for VSFilter.dll codec pack crash

### DIFF
--- a/SilentPatchBully/SilentPatchBully.cpp
+++ b/SilentPatchBully/SilentPatchBully.cpp
@@ -438,6 +438,18 @@ namespace SEALeaksFix
 	}
 };
 
+// ============= Skip XACT init if VSFilter.dll is present (codec pack crash) =============
+namespace CodecCompatFix
+{
+	static char __cdecl XactInitGuard(void* Src, int Size)
+	{
+		if(GetModuleHandleW(L"VSFilter.dll") != nullptr)
+		{
+			return 0; // skip audio init, prevent XAudio2 AV
+		}
+		return ((char(__cdecl*)(void*, int))0x5AE2A0)(Src, Size);
+	}
+}
 
 void InjectHooks()
 {
@@ -953,6 +965,16 @@ void InjectHooks()
 		Patch<int8_t>( 0x5A99AF, 1 );
 		ReadCall( 0x5A9A1F, MDXactCreateSoundBankCommand );
 		InjectHook( 0x5A9A1F, MDXactCreateSoundBankWithManagedDataCommand );
+	}
+
+	// Skip XACT audio initialization if VSFilter.dll (DirectVobSub) is loaded.
+	// FreeCodecPack/K-Lite's VSFilter hooks the DirectShow filter graph and causes
+	// XAudio2_1.dll to AV during engine creation (null pointer read at ~0x22768).
+	// The game handles audio-init failure gracefully: it shows SOUND_INIT_FAILED_MSG
+	// and continues without audio.
+	{
+		using namespace CodecCompatFix;
+		InjectHook( 0x5AF130, XactInitGuard, PATCH_JUMP );
 	}
 }
 


### PR DESCRIPTION
In https://github.com/CookiePLMonster/SilentPatchBully/issues/117 , I found that through the crash dumps [ https://drive.google.com/file/d/1vjgWoCH0ptoyQndwovnhn1V1sH8xzzHH/view?usp=drive_link ], me and my agent found that it crashes at the address in `0x543F2768` and used IDA Pro and x32dbg to find that location. It 's casued by "FreeCodecPack/K-Lite's VSFilter" which is suspect the person has when running Steam. 

I've tried to reproduce this myself with the 3.0.0.236 version from [ https://www.dll-files.com/vsfilter.dll.html ] and setting that as my default audio system, but it didn't crash in runtime. I'm not sure if it's version specific or what. But I'm willing to bet it is, through my extensive parsing of data with my agent.

You can find my agent's markdown here:
[IMPLEMENTATION_VSFilter_XAudio2Compat.md](https://github.com/user-attachments/files/28341105/IMPLEMENTATION_VSFilter_XAudio2Compat.md)

It's verbose, I know, but I've made sure it's clear to read in VS Code.


Here's the commit log:
```
FreeCodecPack/K-Lite's VSFilter (DirectVobSub) hooks the DirectShow filter graph and causes XAudio2_1.dll to AV with a null pointer read (~0x22768) during XACT engine creation on startup.

This fix hooks sub_5AF130 (XACT init thunk) and checks if VSFilter.dll is mapped. If present, it skips audio initialization - the game handles this gracefully by showing SOUND_INIT_FAILED_MSG and continuing.

Fixes startup crash reported in Bully.exe.20240910101526.dmp
```